### PR TITLE
Odoo doc fix: publish db container ports

### DIFF
--- a/odoo/README.md
+++ b/odoo/README.md
@@ -18,7 +18,7 @@ This image requires a running PostgreSQL server.
 
 ## Start a PostgreSQL server
 
-	docker run -d -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo --name db postgres
+	docker run -P -d -e POSTGRES_USER=odoo -e POSTGRES_PASSWORD=odoo --name db postgres
 
 ## Start an Odoo instance
 


### PR DESCRIPTION
Without the -P option, the PostgreSQL database running inside db
container was not accessible from the odoo container.
